### PR TITLE
Weth payment

### DIFF
--- a/contracts/RevenueBuffer.sol
+++ b/contracts/RevenueBuffer.sol
@@ -45,6 +45,8 @@ contract RevenueBuffer is AccessControl{
       _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
   }
 
+  event ReceivedETH(uint256 receivedId, uint256 amount);
+  event ReceivedWETH(uint256 receivedId, uint256 amount);
   event RequestAdded(uint tokenId, uint256 amount, address[] m);
   event WithdrawedETH(address indexed account, uint256 indexed amount);
   event WithdrawedWETH(address indexed account, uint256 indexed amount);
@@ -86,6 +88,7 @@ contract RevenueBuffer is AccessControl{
     ++receiveId;
     receiveIdToPayments[receiveId] = Payment(msg.value, false);
     totalReceivedETH += msg.value;
+    emit ReceivedETH(receiveId, msg.value);
   }
 
   // update receivedWETH
@@ -97,6 +100,7 @@ contract RevenueBuffer is AccessControl{
       totalReceivedWETH += bal - WETHbalance;
       WETHbalance = bal;
     }
+    emit ReceivedWETH(receiveId, msg.value);
   }
 
   function batchWithdraw() external onlyRole(WITHDRAWER_ROLE) payable {

--- a/contracts/RevenueBuffer.sol
+++ b/contracts/RevenueBuffer.sol
@@ -59,7 +59,6 @@ contract RevenueBuffer is AccessControl{
   }
 
   function addRequest(uint tokenId, address[] memory m) external onlyRole(DEFAULT_ADMIN_ROLE) {
-    // TODO: check any update of receiveing amount of WETH.
     updateReceivedWETH();
     require(requestId == receiveId -1, "Invalid requestId");
     ++requestId;
@@ -93,6 +92,7 @@ contract RevenueBuffer is AccessControl{
 
   // update receivedWETH
   function updateReceivedWETH() internal {
+    require(WETH != address(0), "failed setTokenAddress");
     uint256 bal = IERC20(WETH).balanceOf(address(this));
     if(bal > WETHbalance) {
       ++receiveId;

--- a/contracts/RevenueBuffer.sol
+++ b/contracts/RevenueBuffer.sol
@@ -2,17 +2,30 @@
 pragma solidity ^0.8.9;
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/utils/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract RevenueBuffer is AccessControl{
   using SafeMath for uint256;
   uint256 public receiveId;
   uint256 public requestId;
   uint256 public withdrawnId;
+  address public WETH;
 
-  uint public totalReceived;
-  mapping(address=>uint256) public claimablePerAddress;
-  mapping(address=>uint256) public withdrawnPerAddress;
-  mapping(uint256=>uint256) public receiveIdToAmount;
+
+  uint public totalReceivedETH;
+  uint public totalReceivedWETH;
+  uint public WETHbalance;
+  mapping(address=>Amount) public claimablePerAddress;
+  mapping(address=>Amount) public withdrawnPerAddress;
+  struct Amount {
+    uint256 amountETH;
+    uint256 amountWETH;
+  }
+  mapping(uint256=>Payment) public receiveIdToPayments;
+  struct Payment {
+    uint256 amount;
+    bool isWETH;
+  }
   mapping(uint256=>Request) public requestIdToRequest;
   struct Request {
       uint256 tokenId;
@@ -33,67 +46,110 @@ contract RevenueBuffer is AccessControl{
   }
 
   event RequestAdded(uint tokenId, uint256 amount, address[] m);
-  event Withdrawed(address indexed account, uint256 indexed amount);
+  event WithdrawedETH(address indexed account, uint256 indexed amount);
+  event WithdrawedWETH(address indexed account, uint256 indexed amount);
   event WithdrawerAdded(address withdrawer);
   event WithdrawerRemoved(address withdrawer);
 
+  function setTokenAddress(address token_) external onlyRole(DEFAULT_ADMIN_ROLE) {
+      require(token_ != address(0), "Invalid token address");
+      WETH = token_;
+  }
+
   function addRequest(uint tokenId, address[] memory m) external onlyRole(DEFAULT_ADMIN_ROLE) {
-    // TODO: commentout
+    // TODO: check any update of receiveing amount of WETH.
+    updateReceivedWETH();
     require(requestId == receiveId -1, "Invalid requestId");
     ++requestId;
-    uint256 amount = receiveIdToAmount[requestId];
+    uint256 amount = receiveIdToPayments[requestId].amount;
+    bool isWETH = receiveIdToPayments[requestId].isWETH;
     require(amount > 0, "request amount should be > 0");
+    //amount is given by receivedIdToPayments
     Request memory request =  Request(tokenId, amount, m);
     requestIdToRequest[requestId] = request;
     (bool res, uint256 revenuePerMember) = amount.tryDiv(m.length);
     require(res, "Failed to devide receive amount");
     for(uint i=0; i<m.length; i++) {
-      claimablePerAddress[m[i]] += revenuePerMember;
+      if (isWETH) {
+        claimablePerAddress[m[i]].amountWETH += revenuePerMember;
+      } else {
+        claimablePerAddress[m[i]].amountETH += revenuePerMember;
+      }
       MemberAmount memory ma = MemberAmount(m[i], revenuePerMember);
       tokenIdToMemberAmounts[tokenId].push(ma);
     }
     emit RequestAdded(tokenId, amount, m);
   }
 
-  receive () external payable {
+  //receive ETH
+  receive() external payable {
     ++receiveId;
-    receiveIdToAmount[receiveId] = msg.value;
-    totalReceived += msg.value;
+    receiveIdToPayments[receiveId] = Payment(msg.value, false);
+    totalReceivedETH += msg.value;
+  }
+
+  // update receivedWETH
+  function updateReceivedWETH() internal {
+    uint256 bal = IERC20(WETH).balanceOf(address(this));
+    if(bal > WETHbalance) {
+      ++receiveId;
+      receiveIdToPayments[receiveId] = Payment(bal - WETHbalance, true);
+      totalReceivedWETH += bal - WETHbalance;
+      WETHbalance = bal;
+    }
   }
 
   function batchWithdraw() external onlyRole(WITHDRAWER_ROLE) payable {
     require(withdrawnId < requestId, "No Withdrawable Request");
     // transfer claimablePerAddress to all addresses if the amount is not zero.
-    // how to get the wallet list: requestIdToRequest[requestId(itterable)].members
+    // to get the wallet list: requestIdToRequest[requestId(itterable)].members
     for(uint i=withdrawnId; i<=requestId; i++) {
       address[] memory m = requestIdToRequest[i].members;
       for (uint j=0; j<m.length; j++) {
-        if(claimablePerAddress[m[j]] > 0){
-          address account = m[j];
-          uint256 payment = claimablePerAddress[account];
-          withdrawnPerAddress[account] += payment;
-          claimablePerAddress[account] = 0;
-          totalReceived -= payment;
-          _transfer(account, payment);
-          emit Withdrawed(account, payment);
+        address account = m[j];
+        if(claimablePerAddress[account].amountETH > 0){
+          uint256 claimableETH = claimablePerAddress[account].amountETH;
+          withdrawnPerAddress[account].amountETH += claimableETH;
+          claimablePerAddress[account].amountETH = 0;
+          totalReceivedETH -= claimableETH;
+          _transfer(account, claimableETH);
+          emit WithdrawedETH(account, claimableETH);
+        }
+        if(claimablePerAddress[account].amountWETH > 0){
+          uint256 claimableWETH = claimablePerAddress[account].amountWETH;
+          withdrawnPerAddress[account].amountWETH += claimableWETH;
+          claimablePerAddress[account].amountWETH = 0;
+          totalReceivedWETH -= claimableWETH;
+          IERC20(WETH).transfer(account, claimableWETH);
+          emit WithdrawedWETH(account, claimableWETH);
         }
       }
     }
     withdrawnId = requestId;
   }
 
-  function withdraw(address account, uint amount) external onlyRole(WITHDRAWER_ROLE) payable {
-    require(claimablePerAddress[account] > 0, "Account has no claimable amount.");
-    require(claimablePerAddress[account] > amount, "Amount exceeds claimable amount.");
-    claimablePerAddress[account] -= amount;
-    totalReceived -= amount;
-    withdrawnPerAddress[account] += amount;
+  function withdrawETH(address account, uint amount) external onlyRole(WITHDRAWER_ROLE) payable {
+    require(claimablePerAddress[account].amountETH > 0, "Account has no claimable amount.");
+    require(claimablePerAddress[account].amountETH > amount, "Amount exceeds claimable amount.");
+    claimablePerAddress[account].amountETH -= amount;
+    totalReceivedETH -= amount;
+    withdrawnPerAddress[account].amountETH += amount;
     _transfer(account, amount);
-    emit Withdrawed(account, amount);
+    emit WithdrawedETH(account, amount);
+  }
+
+  function withdrawWETH(address account, uint amount) external onlyRole(WITHDRAWER_ROLE) payable {
+    require(claimablePerAddress[account].amountWETH > 0, "Account has no claimable amount.");
+    require(claimablePerAddress[account].amountWETH > amount, "Amount exceeds claimable amount.");
+    claimablePerAddress[account].amountWETH -= amount;
+    totalReceivedWETH -= amount;
+    withdrawnPerAddress[account].amountWETH += amount;
+    IERC20(WETH).transfer(account, amount);
+    emit WithdrawedWETH(account, amount);
   }
   
   ////
-  // add and remove provider_role to an address
+  // add and remove Withdrawer
   ////
 
   function addProvider(address withdrawer) external onlyRole(DEFAULT_ADMIN_ROLE) {

--- a/contracts/WhitelistNFT.sol
+++ b/contracts/WhitelistNFT.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+import "erc721a/contracts/ERC721A.sol";
+
+contract WhitelistNFT is ERC721A {
+    bytes32 immutable public merkleRoot;
+    uint256 public MAX_TOKENS;
+    uint256 public MAX_MINTS;
+    mapping(address => uint256) public claimedAmount;
+
+    constructor(
+        bytes32 _merkleRoot,
+        uint256 _maxTokens,
+        uint256 _maxMints
+    )
+    ERC721A("WhitelistNFT", "WLNFT"){
+        merkleRoot = _merkleRoot;
+        MAX_TOKENS = _maxTokens;
+        MAX_MINTS = _maxMints;
+    }
+
+    function toBytes32(address addr) pure internal returns (bytes32) {
+        return bytes32(uint256(uint160(addr)));
+    }
+
+    function mintTokens(bytes32[] calldata merkleProof, uint256 numberOfTokens) public payable {
+        require(claimedAmount[msg.sender] + numberOfTokens <= MAX_MINTS, "No more claim");
+        claimedAmount[msg.sender] += numberOfTokens;
+        require(MerkleProof.verify(merkleProof, merkleRoot, toBytes32(msg.sender)), "Invalid MerkleProof");
+        _mint(msg.sender, numberOfTokens);
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,10 +19,15 @@
         "@nomicfoundation/hardhat-toolbox": "^1.0.2",
         "@nomiclabs/hardhat-ethers": "^2.1.1",
         "@nomiclabs/hardhat-etherscan": "^3.1.0",
+        "assert": "^2.0.0",
+        "chai": "^4.3.6",
+        "chai-as-promised": "^7.1.1",
+        "crypto-js": "^4.1.1",
         "dotenv": "^16.0.2",
         "erc721a": "^4.2.2",
         "ethers": "^5.7.0",
-        "hardhat": "^2.10.1"
+        "hardhat": "^2.10.1",
+        "merkletreejs": "^0.2.32"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -2907,6 +2912,18 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/assert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
+      "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
+      "dev": true,
+      "dependencies": {
+        "es6-object-assign": "^1.1.0",
+        "is-nan": "^1.2.1",
+        "object-is": "^1.0.1",
+        "util": "^0.12.0"
+      }
+    },
     "node_modules/assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -2922,7 +2939,6 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -2992,7 +3008,6 @@
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3325,6 +3340,12 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/buffer-reverse": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-reverse/-/buffer-reverse-1.0.1.tgz",
+      "integrity": "sha512-M87YIUBsZ6N924W57vDwT/aOu8hw7ZgdByz6ijksLjmHJELBASmYTTlNHRgjE+pTsT9oJXGaDSgqqwfdHotDUg==",
+      "dev": true
+    },
     "node_modules/buffer-to-arraybuffer": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
@@ -3456,7 +3477,6 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
       "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
@@ -3475,7 +3495,6 @@
       "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
       "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "check-error": "^1.0.2"
       },
@@ -3488,7 +3507,6 @@
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "type-detect": "^4.0.0"
       },
@@ -3525,7 +3543,6 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -4071,6 +4088,12 @@
         "node": "*"
       }
     },
+    "node_modules/crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==",
+      "dev": true
+    },
     "node_modules/d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -4224,7 +4247,6 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
       "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
@@ -4524,7 +4546,6 @@
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
       "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -4569,7 +4590,6 @@
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -4609,6 +4629,12 @@
         "es5-ext": "^0.10.35",
         "es6-symbol": "^3.1.1"
       }
+    },
+    "node_modules/es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==",
+      "dev": true
     },
     "node_modules/es6-symbol": {
       "version": "3.1.3",
@@ -5376,7 +5402,6 @@
       "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.10.tgz",
       "integrity": "sha512-rxJ5OFN3RwjQxDcFP2Z5+Q9ho4eIdEmSc2ht0fCu8Se9nbXjZ7/031uXoUYJ87KHCOdVeiUuwSnoS7hmYAGVHA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "js-sha3": "^0.8.0"
       }
@@ -5513,7 +5538,6 @@
       "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
       "integrity": "sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "bn.js": "4.11.6",
         "number-to-bn": "1.7.0"
@@ -5527,8 +5551,7 @@
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
       "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/ethjs-util": {
       "version": "0.1.6",
@@ -5916,7 +5939,6 @@
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "is-callable": "^1.1.3"
       }
@@ -6033,7 +6055,6 @@
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
       "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -6058,7 +6079,6 @@
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true,
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6116,7 +6136,6 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -6163,7 +6182,6 @@
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
       "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
@@ -6739,7 +6757,6 @@
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
       "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true,
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6758,7 +6775,6 @@
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
       "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "get-intrinsic": "^1.1.1"
       },
@@ -6806,7 +6822,6 @@
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -7089,7 +7104,6 @@
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
       "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
@@ -7133,7 +7147,6 @@
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
       "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -7150,7 +7163,6 @@
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
       "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "has-bigints": "^1.0.1"
       },
@@ -7175,7 +7187,6 @@
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
       "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -7216,7 +7227,6 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
       "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -7229,7 +7239,6 @@
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -7271,7 +7280,6 @@
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
       "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -7304,12 +7312,27 @@
         "npm": ">=3"
       }
     },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-negative-zero": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
       "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -7331,7 +7354,6 @@
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
       "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -7366,7 +7388,6 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -7393,7 +7414,6 @@
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
       "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2"
       },
@@ -7422,7 +7442,6 @@
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
       "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -7438,7 +7457,6 @@
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
       "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -7454,7 +7472,6 @@
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.9.tgz",
       "integrity": "sha512-kfrlnTTn8pZkfpJMUgYD7YZ3qzeJgWUn8XfVYBARc4wnmNOmLbmuuaAs3q5fvB0UJOn6yHAKaGTPM7d6ezoD/A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
@@ -7493,7 +7510,6 @@
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
       "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2"
       },
@@ -8125,7 +8141,6 @@
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
       "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "get-func-name": "^2.0.0"
       }
@@ -8306,6 +8321,28 @@
         "readable-stream": "^3.6.0",
         "semaphore-async-await": "^1.5.1"
       }
+    },
+    "node_modules/merkletreejs": {
+      "version": "0.2.32",
+      "resolved": "https://registry.npmjs.org/merkletreejs/-/merkletreejs-0.2.32.tgz",
+      "integrity": "sha512-TostQBiwYRIwSE5++jGmacu3ODcKAgqb0Y/pnIohXS7sWxh1gCkSptbmF1a43faehRDpcHf7J/kv0Ml2D/zblQ==",
+      "dev": true,
+      "dependencies": {
+        "bignumber.js": "^9.0.1",
+        "buffer-reverse": "^1.0.1",
+        "crypto-js": "^3.1.9-1",
+        "treeify": "^1.1.0",
+        "web3-utils": "^1.3.4"
+      },
+      "engines": {
+        "node": ">= 7.6.0"
+      }
+    },
+    "node_modules/merkletreejs/node_modules/crypto-js": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
+      "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q==",
+      "dev": true
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -8897,7 +8934,6 @@
       "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
       "integrity": "sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "bn.js": "4.11.6",
         "strip-hex-prefix": "1.0.0"
@@ -8911,8 +8947,7 @@
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
       "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/oauth-sign": {
       "version": "0.9.0",
@@ -8952,12 +8987,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -8967,7 +9017,6 @@
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
       "integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -9240,7 +9289,6 @@
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -9645,7 +9693,6 @@
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
       "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -10723,7 +10770,6 @@
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
       "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -10738,7 +10784,6 @@
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
       "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -11200,6 +11245,15 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "node_modules/treeify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
+      "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/true-case-path": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-2.2.1.tgz",
@@ -11424,7 +11478,6 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -11581,7 +11634,6 @@
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
       "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-bigints": "^1.0.2",
@@ -11676,15 +11728,13 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
       "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/util": {
       "version": "0.12.4",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
       "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
@@ -12359,7 +12409,6 @@
       "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.5.tgz",
       "integrity": "sha512-9AqNOziQky4wNQadEwEfHiBdOZqopIHzQQVzmvvv6fJwDSMhP+khqmAZC7YTiGjs0MboyZ8tWNivqSO1699XQw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "bn.js": "^5.2.1",
         "ethereum-bloom-filters": "^1.0.6",
@@ -12485,7 +12534,6 @@
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
@@ -12509,7 +12557,6 @@
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
       "integrity": "sha512-Jn4e5PItbcAHyLoRDwvPj1ypu27DJbtdYXUa5zsinrUx77Uvfb0cXwwnGMTn7cjUfhhqgVQnVJCwF+7cgU7tpw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
@@ -15188,6 +15235,18 @@
         }
       }
     },
+    "assert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
+      "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
+      "dev": true,
+      "requires": {
+        "es6-object-assign": "^1.1.0",
+        "is-nan": "^1.2.1",
+        "object-is": "^1.0.1",
+        "util": "^0.12.0"
+      }
+    },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -15199,8 +15258,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "astral-regex": {
       "version": "2.0.0",
@@ -15260,8 +15318,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -15542,6 +15599,12 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "buffer-reverse": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-reverse/-/buffer-reverse-1.0.1.tgz",
+      "integrity": "sha512-M87YIUBsZ6N924W57vDwT/aOu8hw7ZgdByz6ijksLjmHJELBASmYTTlNHRgjE+pTsT9oJXGaDSgqqwfdHotDUg==",
+      "dev": true
+    },
     "buffer-to-arraybuffer": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
@@ -15644,7 +15707,6 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
       "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
       "dev": true,
-      "peer": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
@@ -15660,7 +15722,6 @@
           "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
           "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
           "dev": true,
-          "peer": true,
           "requires": {
             "type-detect": "^4.0.0"
           }
@@ -15672,7 +15733,6 @@
       "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
       "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "check-error": "^1.0.2"
       }
@@ -15699,8 +15759,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "chokidar": {
       "version": "3.5.3",
@@ -16154,6 +16213,12 @@
         "randomfill": "^1.0.3"
       }
     },
+    "crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==",
+      "dev": true
+    },
     "d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -16274,7 +16339,6 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
       "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
@@ -16533,7 +16597,6 @@
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
       "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -16572,7 +16635,6 @@
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -16602,6 +16664,12 @@
         "es5-ext": "^0.10.35",
         "es6-symbol": "^3.1.1"
       }
+    },
+    "es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==",
+      "dev": true
     },
     "es6-symbol": {
       "version": "3.1.3",
@@ -17228,7 +17296,6 @@
       "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.10.tgz",
       "integrity": "sha512-rxJ5OFN3RwjQxDcFP2Z5+Q9ho4eIdEmSc2ht0fCu8Se9nbXjZ7/031uXoUYJ87KHCOdVeiUuwSnoS7hmYAGVHA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "js-sha3": "^0.8.0"
       }
@@ -17354,7 +17421,6 @@
       "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
       "integrity": "sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "bn.js": "4.11.6",
         "number-to-bn": "1.7.0"
@@ -17364,8 +17430,7 @@
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
           "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -17699,7 +17764,6 @@
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "is-callable": "^1.1.3"
       }
@@ -17794,7 +17858,6 @@
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
       "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -17812,8 +17875,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "gaxios": {
       "version": "5.0.1",
@@ -17854,8 +17916,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "get-intrinsic": {
       "version": "1.1.2",
@@ -17890,7 +17951,6 @@
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
       "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
@@ -18333,8 +18393,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
       "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "has-flag": {
       "version": "3.0.0",
@@ -18347,7 +18406,6 @@
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
       "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "get-intrinsic": "^1.1.1"
       }
@@ -18380,7 +18438,6 @@
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
@@ -18610,7 +18667,6 @@
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
       "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
@@ -18645,7 +18701,6 @@
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
       "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -18656,7 +18711,6 @@
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
       "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "has-bigints": "^1.0.1"
       }
@@ -18675,7 +18729,6 @@
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
       "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -18692,15 +18745,13 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
       "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "is-date-object": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -18730,7 +18781,6 @@
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
       "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
       "dev": true,
-      "peer": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -18750,12 +18800,21 @@
       "integrity": "sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==",
       "dev": true
     },
+    "is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      }
+    },
     "is-negative-zero": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
       "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "is-number": {
       "version": "7.0.0",
@@ -18768,7 +18827,6 @@
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
       "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -18791,7 +18849,6 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -18809,7 +18866,6 @@
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
       "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "call-bind": "^1.0.2"
       }
@@ -18832,7 +18888,6 @@
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
       "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -18842,7 +18897,6 @@
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
       "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
@@ -18852,7 +18906,6 @@
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.9.tgz",
       "integrity": "sha512-kfrlnTTn8pZkfpJMUgYD7YZ3qzeJgWUn8XfVYBARc4wnmNOmLbmuuaAs3q5fvB0UJOn6yHAKaGTPM7d6ezoD/A==",
       "dev": true,
-      "peer": true,
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
@@ -18879,7 +18932,6 @@
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
       "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "call-bind": "^1.0.2"
       }
@@ -19421,7 +19473,6 @@
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
       "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "get-func-name": "^2.0.0"
       }
@@ -19584,6 +19635,27 @@
         "level-ws": "^2.0.0",
         "readable-stream": "^3.6.0",
         "semaphore-async-await": "^1.5.1"
+      }
+    },
+    "merkletreejs": {
+      "version": "0.2.32",
+      "resolved": "https://registry.npmjs.org/merkletreejs/-/merkletreejs-0.2.32.tgz",
+      "integrity": "sha512-TostQBiwYRIwSE5++jGmacu3ODcKAgqb0Y/pnIohXS7sWxh1gCkSptbmF1a43faehRDpcHf7J/kv0Ml2D/zblQ==",
+      "dev": true,
+      "requires": {
+        "bignumber.js": "^9.0.1",
+        "buffer-reverse": "^1.0.1",
+        "crypto-js": "^3.1.9-1",
+        "treeify": "^1.1.0",
+        "web3-utils": "^1.3.4"
+      },
+      "dependencies": {
+        "crypto-js": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
+          "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q==",
+          "dev": true
+        }
       }
     },
     "methods": {
@@ -20045,7 +20117,6 @@
       "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
       "integrity": "sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==",
       "dev": true,
-      "peer": true,
       "requires": {
         "bn.js": "4.11.6",
         "strip-hex-prefix": "1.0.0"
@@ -20055,8 +20126,7 @@
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
           "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -20086,19 +20156,27 @@
       "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
       "dev": true
     },
+    "object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "object.assign": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
       "integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -20313,8 +20391,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "pbkdf2": {
       "version": "3.1.2",
@@ -20632,7 +20709,6 @@
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
       "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -21483,7 +21559,6 @@
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
       "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
       "dev": true,
-      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -21495,7 +21570,6 @@
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
       "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -21870,6 +21944,12 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "treeify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
+      "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
+      "dev": true
+    },
     "true-case-path": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-2.2.1.tgz",
@@ -22040,8 +22120,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "type-fest": {
       "version": "0.21.3",
@@ -22154,7 +22233,6 @@
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
       "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-bigints": "^1.0.2",
@@ -22227,15 +22305,13 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
       "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "util": {
       "version": "0.12.4",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
       "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
@@ -22842,7 +22918,6 @@
       "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.5.tgz",
       "integrity": "sha512-9AqNOziQky4wNQadEwEfHiBdOZqopIHzQQVzmvvv6fJwDSMhP+khqmAZC7YTiGjs0MboyZ8tWNivqSO1699XQw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "bn.js": "^5.2.1",
         "ethereum-bloom-filters": "^1.0.6",
@@ -22936,7 +23011,6 @@
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
@@ -22957,7 +23031,6 @@
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
       "integrity": "sha512-Jn4e5PItbcAHyLoRDwvPj1ypu27DJbtdYXUa5zsinrUx77Uvfb0cXwwnGMTn7cjUfhhqgVQnVJCwF+7cgU7tpw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,15 @@
     "@nomicfoundation/hardhat-toolbox": "^1.0.2",
     "@nomiclabs/hardhat-ethers": "^2.1.1",
     "@nomiclabs/hardhat-etherscan": "^3.1.0",
+    "assert": "^2.0.0",
+    "chai": "^4.3.6",
+    "chai-as-promised": "^7.1.1",
+    "crypto-js": "^4.1.1",
     "dotenv": "^16.0.2",
     "erc721a": "^4.2.2",
     "ethers": "^5.7.0",
-    "hardhat": "^2.10.1"
+    "hardhat": "^2.10.1",
+    "merkletreejs": "^0.2.32"
   },
   "dependencies": {
     "@opensea/stream-js": "^0.0.20",

--- a/provider/index.js
+++ b/provider/index.js
@@ -13,16 +13,21 @@ const abi  =  require ("../artifacts/contracts/RevenueBuffer.sol/RevenueBuffer.j
 const updateRequest = async (tokenId, members) => {
   // get deployer(Admin) address of revenuBuffer contract
   const deployer = process.env.DEPLOYER;
-  // deployed RevenueBuffer contract on Rinkeby
-  const address = '0x23Cb1a2912772E413Eceb469Cd4b4F20a3FA6386';
+  // deployed RevenueBuffer contract address on Rinkeby
+  const address = '0xf4102568FeBBbca13C8814501f598080e32A503E';
   // Provider
   const network = ethers.providers.getNetwork("rinkeby");
   const alchemyProvider = new ethers.providers.AlchemyProvider(network, process.env.APIKEY);
   // Signer(deployer address derived from PRIVKEY)
   const signer = new ethers.Wallet(process.env.PRIVKEY, alchemyProvider);
-  // get contract instance
-  const RevenueBuffer = await new ethers.Contract(address, abi.default.abi, signer);
+  // get contract instancess
+  const RevenueBuffer = await new ethers.Contract(address, abi.abi, signer);
   const revenueBuffer = await RevenueBuffer.attach(address);
+  // Confirm: setTokenAddress() is ready.
+  const address_WETH = await revenueBuffer.WETH();
+  console.log("address_WETH:", address_WETH);
+  if(address_WETH == "0x00") return;
+
   try {
     // Write contract
     const tx = await revenueBuffer.addRequest(tokenId, members);
@@ -80,9 +85,9 @@ const sampleEvent = {
         "item": {
           "nft_id":"ethereum/0x8a90cab2b38dba80c64b7734e58ee1db38b8992e/222",
           "permalink":"https://opensea.io/assets/0x8a90cab2b38dba80c64b7734e58ee1db38b8992e/222",
-          "chain": { "name": "ethereum" },
+          "chain": { "name": "Rinkeby" },
           "metadata": {
-              "name": "Doodle #222",
+              "name": "Mitama test #1",
               "description": "A community-driven collectibles project featuring art by Burnt Toast. Doodles come...",
               "image_url": "https://lh3.googleusercontent.com/R7wtoDNdmM7GhTvVjr4JGA6q60z44Hn2nIymPjAEXcjnD8oBPxQYPA1GkrCnvepPM1Sc8DlIHZql4Yucj4ger1jnWmxmuRFwIC_JRw",
               "animation_url": null,
@@ -93,13 +98,13 @@ const sampleEvent = {
         "payment_token": {
           "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
           "decimals": 18,
-          "eth_price": "1",
-          "name": "Ether",
-          "symbol": "ETH",
+          "eth_price": "0.01",
+          "name": "WrappedEther",
+          "symbol": "WETH",
           "usd_price": "3067.19"
         },
         "quantity": 1,
-        "sale_price": 100500000000000000,
+        "sale_price": 100000000000000000,
         "taker": { "address": "0x338571a641d8c43f9e5a306300c5d89e0cb2cfaf" },
         "transaction": {
           "hash": "0x57135fca40b927fbd741f5a21626c1c4c84e7c1036bb50d3158e2fa62a80c941",
@@ -217,4 +222,6 @@ const main = async (event) => {
 
 // await injectItem(parseItemSoldEvent(sampleEvent));
 // await main(sampleEvent);
-client.onItemSold('henohenomoheji', (e) => main(e));
+
+// client.onItemSold('henohenomoheji', (e) => main(e));
+client.onItemSold('mitama-test-1', (e) => main(e));

--- a/provider/merkleTree-test.js
+++ b/provider/merkleTree-test.js
@@ -1,0 +1,34 @@
+const assert = require('assert');
+const { MerkleTree } = require('merkletreejs')
+const SHA256 = require('crypto-js/sha256')
+
+const list = ['a', 'b', 'c']
+const leaves = list.map(x => SHA256(x))
+const tree = new MerkleTree(leaves, SHA256, {sort: true})
+const treeUnsorted = new MerkleTree(leaves, SHA256)
+const root = tree.getRoot().toString('hex');
+const hexRoot = tree.getHexRoot()
+const leafa = SHA256('a');
+const leafb = SHA256('b');
+const proofa = tree.getProof(leafa);
+const hexProofA = tree.getHexProof(leafa);
+const proofb = tree.getProof(leafb);
+const hexProofB = tree.getHexProof(leafb);
+
+assert.equal('0x'+root, hexRoot);
+// if set to sort, hex verification is true.
+console.log(tree.verify(hexProofA, leafa, hexRoot));// true
+// console.log(tree.toString())
+// └─ 8fee4b5ecf296a85922864113a5b1f05df4a3cc7ff94921309b68f285dfa1cef
+//    ├─ 749b7ca2a54111005e8fd558804ff78333d14b32de9bb15efb5ab282c4dadc81
+//    │  ├─ 2e7d2c03a9507ae265ecf5b5356885a53393a2029d241394997265a1a25aefc6
+//    │  └─ 3e23e8160039594a33894f6564e1b1348bbd7a0088d42c4acb73eeaed59c009d
+//    └─ ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb
+//       └─ ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb
+// console.log(treeUnsorted.toString())
+// └─ 7075152d03a5cd92104887b476862778ec0c87be5c2fa1c0a90f87c49fad6eff
+//    ├─ e5a01fee14e0ed5c48714f22180f25ad8365b53f9779f79dc4a3d7e93963f94a
+//    │  ├─ ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb
+//    │  └─ 3e23e8160039594a33894f6564e1b1348bbd7a0088d42c4acb73eeaed59c009d
+//    └─ 2e7d2c03a9507ae265ecf5b5356885a53393a2029d241394997265a1a25aefc6
+//       └─ 2e7d2c03a9507ae265ecf5b5356885a53393a2029d241394997265a1a25aefc6

--- a/scripts/deployWhitelistNFT.js
+++ b/scripts/deployWhitelistNFT.js
@@ -1,0 +1,46 @@
+const { expect, use } = require('chai')
+const { ethers } = require('hardhat')
+const { MerkleTree } = require('merkletreejs')
+const { keccak256 } = ethers.utils
+
+use(require('chai-as-promised'))
+
+describe('WhitelistNFT', () => {
+    it('Only allows whitelisted address to mintTokens()', async () => {
+        const accounts = await ethers.getSigners()
+        const whitelisted = accounts.slice(0, 5)
+        const notWhitelisted = accounts.slice(5, 10)
+        console.log(notWhitelisted[0].address);
+
+        const padBuffer = (addr) => {
+            // pad address with 0, and conver string(as hex) to Buffer
+            return Buffer.from(addr.substr(2).padStart(32*2, 0), 'hex')
+        }
+
+        // prep tree and root
+        const leaves = whitelisted.map(account => padBuffer(account.address))
+        const tree = new MerkleTree(leaves, keccak256, { sort: true })
+        const merkleRoot = tree.getHexRoot()// stored publically on smartcontract
+
+        // prep badTree
+        const badLeaves = notWhitelisted.map(account => padBuffer(account.address))
+        const badTree = new MerkleTree(badLeaves, keccak256, { sort: true })
+
+        // deploy WhitelistNFT
+        const WhitelistNFT = await ethers.getContractFactory("WhitelistNFT")
+        // constructor(merkleProof, maxTokens, maxMints)
+        const whitelistNFT = await WhitelistNFT.deploy(merkleRoot, "10000", "5")
+        await whitelistNFT.deployed();
+
+        // prep merkleProof for whitelisted#0
+        const merkleProof = tree.getHexProof(padBuffer(whitelisted[0].address))
+        console.log("merkleProof:", merkleProof);
+        // prep merkleProof for notWhitelisted#0
+        const invalidMerkleProof = badTree.getHexProof(padBuffer(notWhitelisted[0].address))
+        console.log("invalidMerkleProof:", invalidMerkleProof);
+
+        await expect(whitelistNFT.mintTokens(merkleProof, "3")).to.not.be.rejected
+        await expect(whitelistNFT.mintTokens(merkleProof, "3")).to.be.rejectedWith('No more claim')
+        await expect(whitelistNFT.connect(notWhitelisted[0]).mintTokens(invalidMerkleProof, "3")).to.be.rejectedWith('Invalid MerkleProof')
+    })
+})


### PR DESCRIPTION
## Adaption to accept receiving in WETH at `RevenueBuffer.sol`.
premise: WETH is the currency used for offering-based NFT trading on Opensea.
in `RevenueBuffer.sol`
- modify `addRequest` to check if the amount of WETH inside the contract is updated
- modify each struct to have both of `amountETH` and `amountWETH`
- add `receivedWETH` event


## Whitelist using merkleTree verification
- add`whitelistNFT.sol` and `deployWhitelistNFT.js`