### PR TITLE
 Typos Update Mitama.sol  change alon to correct word alone

### DIFF
--- a/contracts/Mitama.sol
+++ b/contracts/Mitama.sol
@@ -307,7 +307,7 @@ contract Mitama is ERC721A, ERC2981, Ownable, MerkleWhitelist, ReentrancyGuard{
     }
     
     /**
-     * House keeping funcitons
+     * House keeping functions
      */
     
     /* ERC721 Setters */


### PR DESCRIPTION
Fix: Typos in Comments Corrected

What Changed
Fixed typographical errors in comments to improve clarity and professionalism. 
In the specified file, you corrected a typo in a comment: changed funcitons to functions.

Why These Changes Were Made
Correcting typos enhances the readability and clarity of the codebase, ensuring a more polished and professional appearance.

Additional Notes
These changes are limited to comments only and do not impact the code's functionality.